### PR TITLE
cosmetic modification to make_figure

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -38,8 +38,7 @@ def make_figure(filename_uri, mode='layout', dragmode='drawrect'):
         fig = go.Figure(go.Image(z=im))
     fig.update_layout(margin=dict(t=0, b=0),
                       dragmode=dragmode,
-                      newshape_line={},
-                      activeshape={})
+                      )
     return fig
 
 

--- a/utils.py
+++ b/utils.py
@@ -36,14 +36,10 @@ def make_figure(filename_uri, mode='layout', dragmode='drawrect'):
     else:
         im = io.imread(filename_uri[1:])
         fig = go.Figure(go.Image(z=im))
-    layout = {}
-    for key in fig.layout:
-        layout[key] = fig.layout[key]
-    layout['margin'] = dict(t=0, b=0)
-    layout['dragmode'] = dragmode
-    layout['newshape'] = {'line': {}}
-    layout['activeshape'] = {}
-    fig.update_layout(layout)
+    fig.update_layout(margin=dict(t=0, b=0),
+                      dragmode=dragmode,
+                      newshape_line={},
+                      activeshape={})
     return fig
 
 


### PR DESCRIPTION
This change removes a workaround I had to introduce before plotly.py 4.7. Now the code simply uses `fig.update_layout` without the need to create a `layout` dict. I made the PR to your branch directly since I branched off it.