### PR TITLE
Tweak table style

### DIFF
--- a/app_bounding_box.py
+++ b/app_bounding_box.py
@@ -241,22 +241,28 @@ app.layout = html.Div(
      Output('image_files','data')],
     [Input('add-shape','n_clicks'),
      Input('previous','n_clicks'),
-     Input('next','n_clicks')],
+     Input('next','n_clicks'),
+     Input('graph','relayoutData')],
     [State('annotations-table','data'),
      State('image_files','data'),
-     State('annotations-store','data')]
+     State('annotations-store','data'),
+     State('annotation-type-dropdown','value')]
 )
 def modify_table_entries(add_shape_n_clicks,
                          previous_n_clicks,
                          next_n_clicks,
+                         graph_relayoutData,
                          annotations_table_data,
                          image_files_data,
-                         annotations_store_data):
+                         annotations_store_data,
+                         annotation_type):
     cbcontext = [p['prop_id'] for p in dash.callback_context.triggered][0]
     if cbcontext == 'add-shape.n_clicks':
         if annotations_table_data is None:
             annotations_table_data = []
-        annotations_table_data.append(default_table_row())
+        row=default_table_row()
+        row['Type']=annotation_type
+        annotations_table_data.append(row)
         return (annotations_table_data,image_files_data)
     image_index_change=0
     if cbcontext == 'previous.n_clicks':

--- a/app_bounding_box.py
+++ b/app_bounding_box.py
@@ -210,7 +210,8 @@ app.layout = html.Div(
                             columns=[{
                                 'name': 'Timestamp',
                                 'id': 'Timestamp'
-                            }]
+                            }],
+                            style_data={'height': 40}
                         ),
                         # Data table
                         dash_table.DataTable(
@@ -223,6 +224,7 @@ app.layout = html.Div(
                                 ) for n in columns
                             ],
                             editable=True,
+                            style_data={'height': 40},
                             dropdown={
                                 'Type': {
                                     'options':[
@@ -231,7 +233,13 @@ app.layout = html.Div(
                                     ],
                                     'clearable': False
                                 }
+                            },
+                            style_cell_conditional=[
+                            {
+                                'if': {'column_id': 'Type'},
+                                'textAlign': 'left'
                             }
+                        ]
                         )
                     ]
                 ),

--- a/app_bounding_box.py
+++ b/app_bounding_box.py
@@ -148,8 +148,8 @@ app.layout = html.Div(
                     clearable=False
                 ),
                 html.H6('Choose image'),
-                html.Button('Previous', id='previous'),
-                html.Button('Next', id='next'),
+                html.Button('Previous', id='previous',className='button'),
+                html.Button('Next', id='next',className='button'),
                 html.H6("Annotations"),
                 # We use this pattern because we want to be able to download the
                 # annotations by clicking on a button
@@ -157,7 +157,8 @@ app.layout = html.Div(
                        # make invisble, we just want it to click on it
                        style={ 'display': 'none' }),
                 html.Button('Download annotations',
-                            id='download-button'),
+                            id='download-button',
+                            className='button'),
                 html.Div(id='dummy',style={'display':'none'})
             ]
         )

--- a/assets/app_bounding_box_style.css
+++ b/assets/app_bounding_box_style.css
@@ -1,10 +1,12 @@
 /* -- style banner -- */
 
 #main {
-    overflow: hidden;
     display: inline-block;
     background: lightgrey;
     border-radius: 5px;
+}
+
+#annotations-table {
 }
 
 .button {

--- a/assets/app_bounding_box_style.css
+++ b/assets/app_bounding_box_style.css
@@ -34,6 +34,17 @@
     width: 500px;
     background: white;
 }
+#table-container {}
+    
+#timestamp-table {
+    width:20%;
+    float:left;
+}
+
+#annotations-table {
+    width:80%;
+    float:left;
+}
 
 #app-container {
     width: 500px;

--- a/assets/app_bounding_box_style.css
+++ b/assets/app_bounding_box_style.css
@@ -1,8 +1,25 @@
 /* -- style banner -- */
 
 #main {
-    width: 100%;
-    
+    overflow: hidden;
+    display: inline-block;
+    background: lightgrey;
+    border-radius: 5px;
+}
+
+.button {
+    background: lightgrey;
+}
+
+#graph {
+    background: lightgrey;
+}
+
+#logo {
+    display: block;
+    margin: 10px;
+    padding: 5px;
+    width: 500px;
 }
 
 #title {
@@ -11,24 +28,29 @@
     border-radius: 5px;
     margin: 10px;
     padding: 5px;
+    display: inline-block;
+    width: 500px;
+    background: white;
 }
 
 #app-container {
-    width: 600px;
+    width: 500px;
     margin: 10px;
     padding: 5px;
-    float: left;
     border: 1.5px solid grey;
     border-radius: 5px;
+    float: left;
+    background: white;
 }
 
 #sidebar {
-    width: 400px;
+    width: 500px;
     margin: 10px;
     padding: 5px;
     float: left;
     border: 1.5px solid grey;
     border-radius: 5px;
+    background: white;
 }
 
 /*


### PR DESCRIPTION
This PR tries to improve the layout of the two tables side by side:
- same height of the cells
- remove collision between type data and cell dropdown by left-aligning the text (this is a hack. The collision only happens when the dropdown is not clearable. This is probably a bug of the datatable and it would be worth investigating a little more and opening an issue in the datatable repo)