### PR TITLE
If relayoutData triggered don't update without 'shapes' key

### DIFF
--- a/ml_image_segmentation.py
+++ b/ml_image_segmentation.py
@@ -183,8 +183,11 @@ def annotation_react(
     segmentation_data,
 ):
     cbcontext = [p["prop_id"] for p in dash.callback_context.triggered][0]
-    if cbcontext == "graph.relayoutData" and "shapes" in graph_relayoutData.keys():
-        masks_data["shapes"] = graph_relayoutData["shapes"]
+    if cbcontext == "graph.relayoutData":
+        if "shapes" in graph_relayoutData.keys():
+            masks_data["shapes"] = graph_relayoutData["shapes"]
+        else:
+            return dash.no_update
     images = [DEFAULT_IMAGE_PATH]
     stroke_width = int(round(2 ** (stroke_width_value)))
     fig = mf(


### PR DESCRIPTION
The makes it so only shape drawing triggers a computation of segmentation (if
the checkbox is active).
closes #18